### PR TITLE
Address blocking problems with PR #407

### DIFF
--- a/drizzlepac/hlautils/processing_utils.py
+++ b/drizzlepac/hlautils/processing_utils.py
@@ -78,7 +78,7 @@ def refine_product_headers(product, obs_dict_info):
     phdu['date-beg'] = (Time(phdu['expstart'], format='mjd').iso, "Starting Date and Time")
     phdu['date-end'] = (Time(phdu['expend'], format='mjd').iso, "Ending Date and Time")
 
-    phdu['equinox'] = 2000.0
+    phdu['equinox'] = hdu[('sci',1)].header['equinox'] if 'equinox' in hdu[('sci',1)].header else 2000.0
 
     # Re-format ACS filter specification
     if phdu['instrume'] == 'ACS':

--- a/drizzlepac/hlautils/se_source_generation.py
+++ b/drizzlepac/hlautils/se_source_generation.py
@@ -346,6 +346,7 @@ def _compute_background(image, box_size=50, win_size=3, nsigma=5., threshold_fla
                 bkg_rms_mean = threshold.max()
             else:
                 bkg_rms_mean = 3. * threshold_flag
+                threshold = bkg_rms_mean
 
             if bkg_rms_mean < 0:
                 bkg_rms_mean = 0.

--- a/drizzlepac/pars/astrodrizzle_filter_hap.cfg
+++ b/drizzlepac/pars/astrodrizzle_filter_hap.cfg
@@ -102,11 +102,11 @@ final_units = cps# Units for final drizzle image (counts or cps)
 
 [STEP 7a: CUSTOM WCS FOR FINAL OUTPUT]
 final_wcs = True# "Define custom WCS for final output image?"
-final_refimage = hst_10265_01_acs_wfc_total_j92c01_drc.fits[1]# Reference image from which to obtain a WCS
+final_refimage = ""# Reference image from which to obtain a WCS
 final_rot = 0.0# "Position Angle of drizzled image's Y-axis w.r.t. North (degrees)"
 final_scale = None# Absolute size of output pixels in arcsec/pixel
-final_outnx = 5549# "Size of FINAL output frame X-axis (pixels)"
-final_outny = 5536# Size of FINAL output frame Y-axis (pixels)
+final_outnx = None# "Size of FINAL output frame X-axis (pixels)"
+final_outny = None# Size of FINAL output frame Y-axis (pixels)
 final_ra = None# right ascension output frame center in decimal degrees
 final_dec = None# declination output frame center in decimal degrees
 final_crpix1 = None# Reference pixel X position on output (CRPIX1)

--- a/drizzlepac/pars/astrodrizzle_single_hap.cfg
+++ b/drizzlepac/pars/astrodrizzle_single_hap.cfg
@@ -102,11 +102,11 @@ final_units = cps# Units for final drizzle image (counts or cps)
 
 [STEP 7a: CUSTOM WCS FOR FINAL OUTPUT]
 final_wcs = True# "Define custom WCS for final output image?"
-final_refimage = hst_10265_01_acs_wfc_total_j92c01_drc.fits[1]# Reference image from which to obtain a WCS
+final_refimage = ""# Reference image from which to obtain a WCS
 final_rot = None# "Position Angle of drizzled image's Y-axis w.r.t. North (degrees)"
 final_scale = None# Absolute size of output pixels in arcsec/pixel
-final_outnx = 5549# "Size of FINAL output frame X-axis (pixels)"
-final_outny = 5536# Size of FINAL output frame Y-axis (pixels)
+final_outnx = None# "Size of FINAL output frame X-axis (pixels)"
+final_outny = None# Size of FINAL output frame Y-axis (pixels)
 final_ra = None# right ascension output frame center in decimal degrees
 final_dec = None# declination output frame center in decimal degrees
 final_crpix1 = None# Reference pixel X position on output (CRPIX1)


### PR DESCRIPTION
This set of changes corrects some problems with PR #407; specifically,

- get astrodrizzle cfg files from drizzlepac installed pars directory
- force output size for all products to be the same 
- add trailer file generation to create all the files (not necessarily the right contents) for the pipeline
- fix default threshold definition in segmentation code
- revise default astrodrizzle_hap.cfg files to not have values specific to a single-visit (ACS pars not useful for WFC3/IR, for example). 
